### PR TITLE
spike commands idea

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ CONFIG_PATH=/etc/browsir
 
 all: build
 
+dev:
+	go run cmd/browsir/main.go
+
 build:
 	go build -o dist/$(BINARY_NAME) ./cmd/browsir
 
@@ -17,6 +20,7 @@ install: build
 	sudo mkdir -p $(CONFIG_PATH)
 	sudo ln -sf "$(PWD)/.browsir.yml" "$(CONFIG_PATH)/config.yml" || true
 	sudo ln -sf "$(PWD)/shortcuts" "$(CONFIG_PATH)/shortcuts" || true
+	sudo ln -sf "$(PWD)/links" "$(CONFIG_PATH)/links" || true
 	sudo ln -sf "$(PWD)/dist/$(BINARY_NAME)" "$(INSTALL_PATH)/$(BINARY_NAME)"
 	@echo "Created symlink to $(BINARY_NAME) in $(INSTALL_PATH)"
 	@echo "Created symlinks to config files in $(CONFIG_PATH)"

--- a/cmd/browsir/main.go
+++ b/cmd/browsir/main.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	cnf "github.com/404answernotfound/browsir/config"
+	browsir "github.com/404answernotfound/browsir/internal"
 	"github.com/404answernotfound/browsir/utils"
 )
 
@@ -15,6 +16,18 @@ func main() {
 	localShortcuts := utils.LoadLocalShortcuts()
 
 	args := os.Args[1:]
+
+	// Check for restricted keywords before parsing flags and running profiles
+	restrictedKeywords := []string{"add-link", "add-shortcut", "rm-link", "search", "list", "preview"}
+
+	for _, keyword := range restrictedKeywords {
+		if strings.Contains(args[0], keyword) {
+			mainCmd := args[0]
+			otherArgs := args[1:]
+			browsir.RunCommand(mainCmd, otherArgs)
+			os.Exit(0)
+		}
+	}
 
 	primitiveFlags := []string{"-v", "--version", "-h", "--help", "-ls", "--list-shortcuts", "-p", "--profiles"}
 	var shouldExit bool

--- a/cmd/browsir/main.go
+++ b/cmd/browsir/main.go
@@ -18,14 +18,19 @@ func main() {
 	args := os.Args[1:]
 
 	// Check for restricted keywords before parsing flags and running profiles
-	restrictedKeywords := []string{"add-link", "add-shortcut", "rm-link", "search", "list", "preview"}
+	restrictedKeywords := []string{"add", "rm", "list", "preview"}
 
 	for _, keyword := range restrictedKeywords {
 		if strings.Contains(args[0], keyword) {
 			mainCmd := args[0]
 			otherArgs := args[1:]
-			browsir.RunCommand(mainCmd, otherArgs)
+			err := browsir.RunCommand(mainCmd, otherArgs)
+			if err != nil {
+				fmt.Println(err)
+			}
 			os.Exit(0)
+		} else {
+			fmt.Errorf("Provide a valid command")
 		}
 	}
 

--- a/internal/browsir.go
+++ b/internal/browsir.go
@@ -1,0 +1,5 @@
+package browsir
+
+func RunCommand(mainCmd string, otherArgs []string) string {
+	return "not implemented"
+}

--- a/internal/browsir.go
+++ b/internal/browsir.go
@@ -1,5 +1,82 @@
 package browsir
 
-func RunCommand(mainCmd string, otherArgs []string) string {
-	return "not implemented"
+import (
+	"fmt"
+
+	"github.com/404answernotfound/browsir/utils"
+)
+
+type ICommand interface {
+	add(args []string)
+	rm(args []string)
+	last(args []string)
+	preview(args []string)
+}
+
+type Command struct{}
+
+// add, rm, list, preview
+func (c Command) add(args []string) error {
+
+	switch args[0] {
+	case "link":
+		flags := utils.GetFlags(args[2:])
+		link := args[1]
+
+		categories, ok := flags["-c"]
+		if !ok {
+			return fmt.Errorf("not a good flag")
+		}
+
+		err := utils.SaveLink(link, categories)
+		if err != nil {
+			return err
+		}
+		return nil
+	case "shortcut":
+		shortcut := args[1]
+		url := args[2]
+		err := utils.SaveLocalShortcut(shortcut, url)
+		return err
+	default:
+		return fmt.Errorf("unknown command: %s", args[0])
+	}
+}
+
+func (c Command) rm(args []string) error {
+	return fmt.Errorf("rm not implemented")
+}
+
+func (c Command) list(args []string) error {
+	links := utils.LoadLinks()
+	for link, categories := range links {
+		fmt.Printf("Link: %s - Categories: %s\n", link, categories)
+	}
+	return nil
+}
+
+func (c Command) preview(args []string) error {
+	return fmt.Errorf("preview not implemented")
+}
+
+func RunCommand(mainCmd string, otherArgs []string) error {
+	command := &Command{}
+	var err error
+
+	switch mainCmd {
+	case "add":
+		err = command.add(otherArgs)
+		return err
+	case "rm":
+		err = command.rm(otherArgs)
+		return err
+	case "list":
+		err = command.list(otherArgs)
+		return err
+	case "preview":
+		err = command.preview(otherArgs)
+		return err
+	default:
+		return fmt.Errorf("not implemented")
+	}
 }

--- a/links.example
+++ b/links.example
@@ -1,0 +1,1 @@
+https://google.com|search engine,google,general

--- a/shortcuts
+++ b/shortcuts
@@ -1,4 +1,0 @@
-facebook=facebook.com
-google=google.com
-github=github.com
-linkedin=linkedin.com

--- a/shortcuts.example
+++ b/shortcuts.example
@@ -1,0 +1,4 @@
+facebook=facebook.com
+google=google.com
+github=github.com
+linkedin=linkedin.com

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -15,27 +15,8 @@ import (
 func LoadLocalShortcuts() map[string]string {
 	shortcuts := make(map[string]string)
 
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return shortcuts
-	}
-
 	// First check system config directory
 	shortcutsPath := "/etc/browsir/shortcuts"
-
-	// Then check XDG config directory
-	if _, err := os.Stat(shortcutsPath); os.IsNotExist(err) {
-		xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
-		if xdgConfigHome == "" {
-			xdgConfigHome = filepath.Join(home, ".config")
-		}
-		shortcutsPath = filepath.Join(xdgConfigHome, "browsir", "shortcuts")
-	}
-
-	// Then check home directory
-	if _, err := os.Stat(shortcutsPath); os.IsNotExist(err) {
-		shortcutsPath = filepath.Join(home, ".browsir_shortcuts")
-	}
 
 	// Finally check current directory
 	if _, err := os.Stat(shortcutsPath); os.IsNotExist(err) {
@@ -61,11 +42,71 @@ func LoadLocalShortcuts() map[string]string {
 	return shortcuts
 }
 
-func SaveLocalShortcut(shortcut, url string) error {
-	home, err := os.UserHomeDir()
+// TODO: Add other paths
+func LoadLinks() map[string]string {
+	var links = make(map[string]string)
+	var linksPath string
+
+	// First check system config directory
+	linksPath = "/etc/browsir/links"
+
+	if _, err := os.Stat(linksPath); os.IsNotExist(err) {
+		linksPath = "links"
+	}
+
+	data, err := os.ReadFile(linksPath)
+	if err != nil {
+		return links
+	}
+
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "|", 2)
+		if len(parts) == 2 {
+			links[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+		}
+	}
+
+	return links
+}
+
+func SaveLink(link string, categories string) error {
+
+	linksPath := "/etc/browsir/links"
+
+	categoriesSlice := strings.Split(categories, ",")
+	var categoriesToString string
+
+	if len(categoriesSlice) == 0 {
+		categoriesToString = "general"
+	}
+
+	categoriesToString = strings.Join(categoriesSlice, ",")
+
+	f, err := os.OpenFile(linksPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err == nil {
+
+		defer f.Close()
+		// Writing to file https://somelink.com|some category
+		_, err = fmt.Fprintf(f, "%s|%s\n", link, categoriesToString)
+		return err
+	}
+
+	f, err = os.OpenFile("links", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}
+	defer f.Close()
+
+	_, err = fmt.Fprintf(f, "%s|%s\n", link, categoriesToString)
+	return err
+}
+
+func SaveLocalShortcut(shortcut, url string) error {
 
 	// First try system config directory
 	shortcutsPath := "/etc/browsir/shortcuts"
@@ -76,31 +117,10 @@ func SaveLocalShortcut(shortcut, url string) error {
 		return err
 	}
 
-	// Then try XDG config directory
-	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
-	if xdgConfigHome == "" {
-		xdgConfigHome = filepath.Join(home, ".config")
-	}
-	configDir := filepath.Join(xdgConfigHome, "browsir")
-	if err := os.MkdirAll(configDir, 0755); err == nil {
-		shortcutsPath := filepath.Join(configDir, "shortcuts")
-		f, err := os.OpenFile(shortcutsPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-		if err == nil {
-			defer f.Close()
-			_, err = fmt.Fprintf(f, "%s=%s\n", shortcut, url)
-			return err
-		}
-	}
-
-	// Then try home directory
-	shortcutsPath = filepath.Join(home, ".browsir_shortcuts")
-	f, err = os.OpenFile(shortcutsPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	// Finally try current directory
+	f, err = os.OpenFile("shortcuts", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		// Finally try current directory
-		f, err = os.OpenFile("shortcuts", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-		if err != nil {
-			return err
-		}
+		return err
 	}
 	defer f.Close()
 
@@ -286,4 +306,10 @@ func Contains(args []string, value string) bool {
 		}
 	}
 	return false
+}
+
+func Log(args ...any) {
+	for _, arg := range args {
+		fmt.Println(arg)
+	}
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -214,6 +214,22 @@ func PrintUsage(profiles []config.Profile, shortcuts map[string]string, localSho
 	fmt.Println("  browsir work                    # Open browser with work profile")
 	fmt.Println("  browsir personal gmail.com      # Open Gmail with personal profile")
 	fmt.Println("  browsir default mail           # Open mail shortcut with default profile")
+
+	fmt.Println("\nOther commands:")
+	fmt.Println("  -h, --help            # Print this help message")
+	fmt.Println("  -v, --version         # Print browsir version")
+	fmt.Println("  -ls, --list-shortcuts # List all shortcuts")
+	fmt.Println("  -p, --profiles        # List all profiles")
+	fmt.Println("  -q        		     # Search the web with a query")
+	fmt.Println("  -se, --search-engine  # Specify search engine (google, duckduckgo, brave)")
+
+	fmt.Println("   browsir add link <link> -c <categories>	# Add a link with categories")
+	fmt.Println("   browsir add shortcut <shortcut> <url>	# Add a local shortcut, do not include http:// or https://")
+	fmt.Println("   browsir rm link <link>					# Remove a link")
+	fmt.Println("   browsir rm shortcut <shortcut>			# Remove a local shortcut")
+	fmt.Println("   browsir list links						# List all links")
+	fmt.Println("   browsir list all						# List all links and categories")
+	fmt.Println("   browsir preview <link>					# Preview a link")
 }
 
 func PrintProfiles(profiles []config.Profile) {


### PR DESCRIPTION
Because of how the implementation of `browsir` is done (and intended), profiles appears as commands.

e.g.

`browsir personal https://example.com`

We don't want to change this behaviour, so this spike serves as proof that we can allow a set of restricted keywords to be checked before browsir profiles and if so, run those commands instead. Thoughts?

