### PR TITLE
fix: list command now handles links and shortcuts correctly, related to issue #46

### DIFF
--- a/internal/browsir.go
+++ b/internal/browsir.go
@@ -21,7 +21,16 @@ type ICommand interface {
 	preview(args []string)
 }
 
-type Command struct{}
+type Command struct {
+	linkLoader LinkLoader
+}
+
+// NewCommand creates a new Command with the default RealLinkLoader
+func NewCommand() *Command {
+	return &Command{
+		linkLoader: &RealLinkLoader{},
+	}
+}
 
 func (c Command) add(args []string) error {
 	switch args[0] {
@@ -81,7 +90,7 @@ func (c Command) remove(args []string) error {
 func (c Command) list(args []string) error {
 	if len(args) == 0 || (len(args) > 0 && (args[0] == "all")) {
 		// List all links and all shortcuts
-		links, err := utils.LoadLinks()
+		links, err := c.linkLoader.LoadLinks()
 		if err == nil {
 			fmt.Println("Links:")
 			for link, categories := range links {
@@ -90,7 +99,7 @@ func (c Command) list(args []string) error {
 		} else {
 			fmt.Fprintf(os.Stderr, "There was an issue loading your links configuration, %v\n", err)
 		}
-		shortcuts, err := utils.LoadLocalShortcuts()
+		shortcuts, err := c.linkLoader.LoadLocalShortcuts()
 		if err == nil {
 			fmt.Println("Shortcuts:")
 			utils.PrintLocalShortcuts(shortcuts)
@@ -101,7 +110,7 @@ func (c Command) list(args []string) error {
 	}
 
 	if args[0] == "links" {
-		links, err := utils.LoadLinks()
+		links, err := c.linkLoader.LoadLinks()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "There was an issue loading your links configuration, %v\n", err)
 			return nil
@@ -114,7 +123,7 @@ func (c Command) list(args []string) error {
 	}
 
 	if args[0] == "shortcuts" {
-		shortcuts, err := utils.LoadLocalShortcuts()
+		shortcuts, err := c.linkLoader.LoadLocalShortcuts()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "There was an issue loading your shortcuts configuration, %v\n", err)
 			return nil
@@ -170,7 +179,7 @@ func (c Command) preview(args []string) error {
 }
 
 func RunCommand(mainCmd string, otherArgs []string) error {
-	command := &Command{}
+	command := NewCommand()
 	var err error
 
 	switch mainCmd {

--- a/internal/browsir.go
+++ b/internal/browsir.go
@@ -79,14 +79,52 @@ func (c Command) remove(args []string) error {
 }
 
 func (c Command) list(args []string) error {
-	links, err := utils.LoadLinks()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "There was an issue loading your links configuration, %v\n", err)
-		os.Exit(0)
+	if len(args) == 0 || (len(args) > 0 && (args[0] == "all")) {
+		// List all links and all shortcuts
+		links, err := utils.LoadLinks()
+		if err == nil {
+			fmt.Println("Links:")
+			for link, categories := range links {
+				fmt.Printf("  %s - Categories: %s\n", link, categories)
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "There was an issue loading your links configuration, %v\n", err)
+		}
+		shortcuts, err := utils.LoadLocalShortcuts()
+		if err == nil {
+			fmt.Println("Shortcuts:")
+			utils.PrintLocalShortcuts(shortcuts)
+		} else {
+			fmt.Fprintf(os.Stderr, "There was an issue loading your shortcuts configuration, %v\n", err)
+		}
+		return nil
 	}
-	for link, categories := range links {
-		fmt.Printf("Link: %s - Categories: %s\n", link, categories)
+
+	if args[0] == "links" {
+		links, err := utils.LoadLinks()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "There was an issue loading your links configuration, %v\n", err)
+			return nil
+		}
+		fmt.Println("Links:")
+		for link, categories := range links {
+			fmt.Printf("  %s - Categories: %s\n", link, categories)
+		}
+		return nil
 	}
+
+	if args[0] == "shortcuts" {
+		shortcuts, err := utils.LoadLocalShortcuts()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "There was an issue loading your shortcuts configuration, %v\n", err)
+			return nil
+		}
+		fmt.Println("Shortcuts:")
+		utils.PrintLocalShortcuts(shortcuts)
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "Unknown argument for list: %s\n", args[0])
 	return nil
 }
 

--- a/internal/browsir_test.go
+++ b/internal/browsir_test.go
@@ -1,0 +1,60 @@
+package browsir
+
+import (
+	"testing"
+
+	"github.com/404answernotfound/browsir/utils"
+)
+
+// MockLoadLinks returns a predefined map of links to test
+func MockLoadLinks() (map[string]string, error) {
+	return map[string]string{
+		"https://example.com": "general",
+		"https://test.com":    "test",
+	}, nil
+}
+
+// MockLoadLocalShortcuts returns a predefined map of shortcuts to test
+func MockLoadLocalShortcuts() (map[string]string, error) {
+	return map[string]string{
+		"shortcut1": "https://shortcut1.com",
+		"shortcut2": "https://shortcut2.com",
+	}, nil
+}
+
+func TestListDefault(t *testing.T) {
+	// Save original functions and restore them after the test
+	originalLoadLinks := utils.LoadLinks
+	originalLoadLocalShortcuts := utils.LoadLocalShortcuts
+	defer func() {
+		utils.LoadLinks = originalLoadLinks
+		utils.LoadLocalShortcuts = originalLoadLocalShortcuts
+	}()
+
+	// Replace with mocks
+	utils.LoadLinks = MockLoadLinks
+	utils.LoadLocalShortcuts = MockLoadLocalShortcuts
+
+	command := Command{}
+	err := command.list([]string{})
+	if err != nil {
+		t.Errorf("list() returned an error: %v", err)
+	}
+}
+
+func TestListLinks(t *testing.T) {
+	// Save original func and restore it after the test
+	originalLoadLinks := utils.LoadLinks
+	defer func() {
+		utils.LoadLinks = originalLoadLinks
+	}()
+
+	// Replace with mokc
+	utils.LoadLinks = MockLoadLinks
+
+	command := Command{}
+	err := command.list([]string{"links"})
+	if err != nil {
+		t.Errorf("list() returned an error: %v", err)
+	}
+} 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -293,9 +293,10 @@ func PrintUsage(profiles []config.Profile, shortcuts map[string]string, localSho
 	fmt.Println("   browsir add shortcut <shortcut> <url>	# Add a local shortcut, do not include http:// or https://")
 	fmt.Println("   browsir rm link <link>					# Remove a link")
 	fmt.Println("   browsir rm shortcut <shortcut>			# Remove a local shortcut")
-	fmt.Println("   browsir list links						# List all links")
-	fmt.Println("   browsir list all						# List all links and categories")
-	fmt.Println("   browsir preview <link>					# Preview a link")
+	fmt.Println("   browsir list                   \t\t\t# List all links and shortcuts")
+	fmt.Println("   browsir list links             \t\t\t# List only links")
+	fmt.Println("   browsir list shortcuts         \t\t\t# List only shortcuts")
+	fmt.Println("   browsir preview <link>         \t\t\t# Preview a link")
 }
 
 func PrintProfiles(profiles []config.Profile) {


### PR DESCRIPTION
### 🔗 Linked issue

[https://github.com/Schroedinger-Hat/browsir/issues/46](https://github.com/Schroedinger-Hat/browsir/issues/46)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The issue was in the list command implementation in internal/browsir.go, where it always loaded and displayed links, ignoring the second argument.

I’ve updated the logic to properly handle:

    browsir list → shows both links and shortcuts
    browsir list links → shows only links
    browsir list shortcuts → shows only shortcuts
  
Solves [issue#46](https://github.com/Schroedinger-Hat/browsir/issues/46)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly. - I did not updated the documentation, the list options are already there
- [x] I have added one or more tests for my pull request